### PR TITLE
Missing dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,9 +8,12 @@ version = 2.1.5
 [Prereqs]
 
 JSON = 0
+JSON::XS = 0
 Catalyst::Action::REST = 0.88
 Catalyst::Action::RenderView = 0
 Catalyst::Runtime = 5.80024
+Catalyst::View::JSON = 0
+Test::WWW::Mechanize::Catalyst = 0
 Moose = 1.21
 Try::Tiny = 0
 


### PR DESCRIPTION
Pretty simple: on a fresh install of perl 5.18.2 (and almost certain others), these modules are needed as well.
