### PR TITLE
Minor perlcritic level 5 fixes.

### DIFF
--- a/lib/CatalystX/ExtJS/Direct.pm
+++ b/lib/CatalystX/ExtJS/Direct.pm
@@ -1,5 +1,8 @@
 package CatalystX::ExtJS::Direct;
 # ABSTRACT: Enable Ext.Direct in Catalyst controllers
+use strict;
+use warnings;
+
 
 1;
 
@@ -12,16 +15,16 @@ __END__
   extends 'CatalystX::Controller::ExtJS::Direct::API';
 
   package MyApp::Controller::Calculator;
-  
+
   use Moose;
   BEGIN { extends 'Catalyst::Controller' };
   with 'CatalystX::Controller::ExtJS::Direct';
-  
+
   sub sum : Local : Direct : DirectArgs(1) {
       my ($self, $c) = @_;
       $c->res->body( $c->req->param('a') + $c->req->param('b') );
   }
-  
+
   1;
 
 In your web application:
@@ -34,7 +37,7 @@ In your web application:
         alert(result);
     });
   </script>
-  
+
 
 =head1 DESCRIPTION
 

--- a/lib/CatalystX/ExtJS/Tutorial/Direct.pm
+++ b/lib/CatalystX/ExtJS/Tutorial/Direct.pm
@@ -1,4 +1,7 @@
 package CatalystX::ExtJS::Tutorial::Direct;
+use strict;
+use warnings;
+
 #ABSTRACT: Introduction to CatalystX::ExtJS::Direct
 1;
 __END__
@@ -6,9 +9,9 @@ __END__
 =head1 INTRODUCTION
 
 Ext.Direct is an ExtJS component which creates classes and methods
-according to an API provided by the server. 
+according to an API provided by the server.
 These methods are used to communicate with the server in a Remote
-Procedure Call fashion. 
+Procedure Call fashion.
 This requires a router on the server side to route the requests to the
 matching method.
 
@@ -21,14 +24,14 @@ Please find a working example of the tutorial at C</tutorial> in the
 L<CatalystX::ExtJS> distribution.
 
 =head1 EXAMPLES
-    
+
 =head2 Simple Calculator
 
 B<Run steps 1 to 5 from L<CatalystX::ExtJS::Tutorial/FIRST STEPS>.>
 
 Every controller which wants to add an action to the Ext.Direct API
-needs to consume the L<CatalystX::Controller::ExtJS::Direct> role. 
-Furthermore each action which should be accessible requires the C<Direct> 
+needs to consume the L<CatalystX::Controller::ExtJS::Direct> role.
+Furthermore each action which should be accessible requires the C<Direct>
 attribute. This simple example adds two numbers and returns
 the result:
 
@@ -36,7 +39,7 @@ the result:
  use Moose;
  BEGIN { extends 'Catalyst::Controller' };
  with 'CatalystX::Controller::ExtJS::Direct';
- 
+
  use JSON::XS;
 
  sub add : Chained('/') : Path : CaptureArgs(1) {
@@ -48,7 +51,7 @@ the result:
     my($self,$c,$arg) = @_;
     $c->res->body( $c->stash->{add} + $arg );
  }
-    
+
  sub echo : Local : Direct : DirectArgs(1) {
     my ($self, $c) = @_;
     $c->res->content_type('application/json');
@@ -79,13 +82,13 @@ Run the server (C<# script/myapp_server.pl -r>) and access
 L<http://localhost:3000/api>.
 You should see something like this:
 
- --- 
- actions: 
-   Calculator: 
-        - 
+ ---
+ actions:
+   Calculator:
+        -
           len: 2
           name: add
-        - 
+        -
           len: 1
           name: echo
  type: remoting
@@ -94,9 +97,9 @@ You should see something like this:
 This is the YAML representation of the API. As you can see, the C<add> method
 expects two parameters and is inside the C<Calculator> class.
 
-If you set the content type header to C<application/json> you will receive 
+If you set the content type header to C<application/json> you will receive
 the JSON-encoded API.
-Try L<http://localhost:3000/api?content-type=application/json> (see 
+Try L<http://localhost:3000/api?content-type=application/json> (see
 L<Catalyst::Controller::REST> to see why this is working).
 
 A different way to access the API is to open L<http://localhost:3000/api/src>.
@@ -106,7 +109,7 @@ Open the C<index> template and add this to the head area:
 
 The API is now available from the variable C<Ext.app.REMOTING_API>.
 
-    
+
 Fire up your favourite browser and go to L<http://localhost:3000/>.
 Open the debugger and type in the console:
 
@@ -114,13 +117,13 @@ Open the debugger and type in the console:
  // This will set up the classes and methods
  // Ext.app.REMOTING_API is provided by /api/src
  Calculator.add(3, 2, function(res){alert(res)});
-    
+
 And watch the request and response. Next we call the C<echo> method.
 
  Calculator.echo({foo: 'bar'}, function(res){console.log(res)});
  // Prints {foo: 'bar'} to your browser's console
 
-    
+
 =head2 RESTful Controllers
 
 
@@ -133,11 +136,11 @@ L<DBIx::Class> and L<HTML::FormFu>. To add such a controller to the
 Direct API, simply add the L<CatalystX::Controller::ExtJS::Direct> role:
 
  package MyApp::Controller::User;
- 
+
  use Moose;
  extends 'CatalystX::Controller::ExtJS::REST';
  with 'CatalystX::Controller::ExtJS::Direct';
- 
+
  1;
 
 L<CatalystX::Controller::ExtJS::REST> expects a L<HTML::FormFu> file to
@@ -153,7 +156,7 @@ be located at C<root/forms/user.yml>:
     - name: email
       constraint: Required
 
-Since the columns C<first>, C<last> and C<email> were defined as 
+Since the columns C<first>, C<last> and C<email> were defined as
 C<NOT NULL> columns, we have to add the C<Required> constraint to them.
 Constraints, however, do not affect C<GET> and C<DELETE> requests.
 If you want a different behaviour for C<POST> or C<PUT> requests, you
@@ -162,24 +165,24 @@ C<root/forms/user_post.yml> accordingly. Same applies to C<GET> requests.
 
 While the CRUD methods (create, read, update, destroy) interact with one
 object only, the C<list> method returns a bunch of objects. By default it
-uses the same configuration file as the other requests. But you can 
+uses the same configuration file as the other requests. But you can
 create it's own file (C<root/lists/user.yml>).
 
 Open L<http://localhost:3000/> and try:
 
   User.list(function(res){console.log('results: ', res.results)});
-  
+
   User.create({first: 'Marge', last: 'Simpson'});
   // this will will cause an error because 'email' is required. The
   // response from the server will contain an error message and the name
   // of the field
-  
+
   User.create({first: 'Marge', last: 'Simpson', email:'marge@simpsons.com'});
-  
+
   User.list(function(res){console.log('results: ', res.results)});
-  
+
   User.destroy(2);
-  
+
 
 =head2 Using Catalyst::Controller::DBIC::API::RPC
 
@@ -192,55 +195,55 @@ convenient.
 Add a new controller C<lib/MyApp/Controller/User/DBIC.pm> and paste:
 
  package MyApp::Controller::User::DBIC;
- 
+
  use Moose;
  extends 'Catalyst::Controller::DBIC::API::RPC';
  with 'CatalystX::Controller::ExtJS::Direct';
- 
+
  # See Catalyst::Controller::DBIC::API for more information
  # on those configuration parameters
- 
+
  __PACKAGE__->config(
-    actions => { 
+    actions => {
         setup  => { PathPart => 'user', Chained => '/' },
         # enable Direct on these actions
-        create => { Direct => undef, DirectArgs => 1 }, 
-        item   => { Direct => undef }, 
-        update => { Direct => undef, DirectArgs => 1 }, 
-        delete => { Direct => undef }, 
-        list   => { Direct => undef, DirectArgs => 1 },  
+        create => { Direct => undef, DirectArgs => 1 },
+        item   => { Direct => undef },
+        update => { Direct => undef, DirectArgs => 1 },
+        delete => { Direct => undef },
+        list   => { Direct => undef, DirectArgs => 1 },
     },
     class => 'DBIC::User',
     use_json_boolean => 1,
     create_requires => [qw(email first last)],
     return_object => 1,
  );
- 
+
  # Catalyst::Controller::DBIC::API cannot handle scalars and arrayrefs so
  # we have to add a little hack
- 
+
  before 'deserialize' => sub {
     my ($self, $c) = @_;
     $c->req->data($c->req->data->[0]) if(ref $c->req->data eq 'ARRAY');
     $c->req->data(undef) unless(ref $c->req->data);
  };
- 
+
  1;
-    
+
 Access L<http://localhost:3000/> in your browser and open the console to
 play around with the DBIC API:
 
  Ext.Direct.addProvider(Ext.app.REMOTING_API);
- 
+
  // get all records from the model
  UserDBIC.list({}, function(res){console.log(res)});
- 
+
  UserDBIC.create({first: 'Marge', last: 'Simpson', email:'marge@simpsons.com'});
- 
+
  UserDBIC.item(2, function(marge){console.log(marge)});
- 
- UserDBIC.delete(2); 
- 
+
+ UserDBIC.delete(2);
+
 Try to run these commands all at once (either put them in one line or use the
 multi-line console in Firebug). They are now being batched and processed in just
 one request.

--- a/t/lib/MyApp/Controller/Calculator.pm
+++ b/t/lib/MyApp/Controller/Calculator.pm
@@ -1,4 +1,6 @@
 package MyApp::Controller::Calculator;
+use strict;
+use warnings;
 
 use Moose;
 

--- a/t/script/myapp_server.pl
+++ b/t/script/myapp_server.pl
@@ -1,14 +1,13 @@
 #!/usr/bin/perl -w
+use strict;
+use warnings;
 
-BEGIN { 
+BEGIN {
     $ENV{CATALYST_ENGINE} ||= 'HTTP';
     $ENV{CATALYST_SCRIPT_GEN} = 31;
     require Catalyst::Engine::HTTP;
-}  
+}
 
-
-use strict;
-use warnings;
 use Getopt::Long;
 use Pod::Usage;
 use FindBin;


### PR DESCRIPTION
Adresses some low hanging fruit, level 5 percritic rule failures.
Primarily not calling use strict and use warnings before code.

Also some empty lines and trailing space clean up.
